### PR TITLE
Use focus_side_ to retrieve rcg::PlayerT focusing information

### DIFF
--- a/rcsc/rcg/types.h
+++ b/rcsc/rcg/types.h
@@ -893,7 +893,7 @@ struct PlayerT {
      */
     bool isFocusing() const
       {
-          return side_ != 'n';
+          return focus_side_ != 'n';
       }
 
     /*!
@@ -947,8 +947,8 @@ struct PlayerT {
      */
     SideID focusSide() const
       {
-          return ( side_ == 'l' ? LEFT
-                   : side_ == 'r' ? RIGHT
+          return ( focus_side_ == 'l' ? LEFT
+                   : focus_side_ == 'r' ? RIGHT
                    : NEUTRAL );
       }
 


### PR DESCRIPTION
Some methods are using `rcg::PlayerT::side_` instead of `rcg::PlayerT::focus_side_` to retrieve information about the *focus* state of a player.

This is a minimal patch that fixes this bug. Please feel free to use it if convenient.