### PR TITLE
PlayerType::getMovableDistance()を追加

### DIFF
--- a/rcsc/common/player_type.cpp
+++ b/rcsc/common/player_type.cpp
@@ -958,6 +958,25 @@ PlayerType::cyclesToReachDistance( const double & dash_dist ) const
 }
 
 /*-------------------------------------------------------------------*/
+double
+PlayerType::getMovableDistance( const size_t step ) const
+{
+    if ( step == 0 )
+    {
+        return 0.0;
+    }
+
+    size_t index = step - 1;
+    if ( index >= M_dash_distance_table.size() )
+    {
+        return M_dash_distance_table.back()
+            + realSpeedMax() * ( index - M_dash_distance_table.size() + 1 );
+    }
+
+    return M_dash_distance_table[index];
+}
+
+/*-------------------------------------------------------------------*/
 /*!
 
 */

--- a/rcsc/common/player_type.h
+++ b/rcsc/common/player_type.h
@@ -460,6 +460,8 @@ public:
       \return estimated cycles to reach
     */
     int cyclesToReachDistance( const double & dash_dist ) const;
+
+    double getMovableDistance( const size_t step ) const;
     ////////////////////////////////////////////////
     /*!
       \brief check if this type player can over player_speed_max


### PR DESCRIPTION
- 指定したステップ数で静止状態から移動可能な距離を返すメソッドを追加
- 50サイクルより大きい場合は最大スピードxステップ数を単純に足し合わせた数値を返す