### PR TITLE
Integreate FormationParser::create() into FormationParser::parse(). N…

### DIFF
--- a/rcsc/formation/formation_parser.cpp
+++ b/rcsc/formation/formation_parser.cpp
@@ -44,9 +44,17 @@ namespace rcsc {
 Formation::Ptr
 FormationParser::parse( const std::string & filepath )
 {
-    std::ifstream fin( filepath.c_str() );
+    FormationParser::Ptr parser = create( filepath );
 
-    return parse( fin );
+    if ( ! parser )
+    {
+        std::cerr << "ERROR (FormationParser::parse) could not create the formation parser instance."
+                  << std::endl;
+        return Formation::Ptr();
+    }
+
+    std::ifstream fin( filepath );
+    return parser->parseImpl( fin );
 }
 
 /*-------------------------------------------------------------------*/

--- a/rcsc/formation/formation_parser.h
+++ b/rcsc/formation/formation_parser.h
@@ -76,12 +76,7 @@ public:
     virtual
     std::string name() const = 0;
 
-    /*!
-      \brief parse the given file
-      \param filepath the file path to be parsed
-      \return formation instance
-     */
-    Formation::Ptr parse( const std::string & filepath );
+protected:
 
     /*!
       \brief parse the input stream
@@ -89,9 +84,7 @@ public:
       \return formation instance
      */
     virtual
-    Formation::Ptr parse( std::istream & is ) = 0;
-
-protected:
+    Formation::Ptr parseImpl( std::istream & is ) = 0;
 
     /*!
       \brief check the consistency of role names
@@ -105,14 +98,24 @@ protected:
      */
     bool checkPositionPair( const Formation::ConstPtr ptr );
 
-public:
+
+private:
 
     /*!
       \brief create formation parser instance according to the header data
       \param filepath the path string of the input file
       \return formation parser instance
      */
-    static FormationParser::Ptr create( const std::string & filepath );
+     static FormationParser::Ptr create( const std::string & filepath );
+
+public:
+
+    /*!
+      \brief parse the given file
+      \param filepath the file path to be parsed
+      \return formation instance
+     */
+    static Formation::Ptr parse( const std::string & filepath );
 
 };
 

--- a/rcsc/formation/formation_parser_csv.cpp
+++ b/rcsc/formation/formation_parser_csv.cpp
@@ -66,7 +66,7 @@ get_value_line( std::istream & is )
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserCSV::parse( std::istream & is )
+FormationParserCSV::parseImpl( std::istream & is )
 {
     const std::string method = parseMethodName( is );
 

--- a/rcsc/formation/formation_parser_csv.h
+++ b/rcsc/formation/formation_parser_csv.h
@@ -66,12 +66,14 @@ public:
         return "csv";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 private:
     std::string parseMethodName( std::istream & is );

--- a/rcsc/formation/formation_parser_json.cpp
+++ b/rcsc/formation/formation_parser_json.cpp
@@ -177,7 +177,7 @@ parse_data( const ptree & doc,
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserJSON::parse( std::istream & is )
+FormationParserJSON::parseImpl( std::istream & is )
 {
     ptree doc;
     try

--- a/rcsc/formation/formation_parser_json.h
+++ b/rcsc/formation/formation_parser_json.h
@@ -66,12 +66,14 @@ public:
         return "json";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 };
 

--- a/rcsc/formation/formation_parser_static.cpp
+++ b/rcsc/formation/formation_parser_static.cpp
@@ -43,7 +43,7 @@ namespace rcsc {
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserStatic::parse( std::istream & is )
+FormationParserStatic::parseImpl( std::istream & is )
 {
     Formation::Ptr ptr( new FormationStatic() );
 

--- a/rcsc/formation/formation_parser_static.h
+++ b/rcsc/formation/formation_parser_static.h
@@ -66,12 +66,14 @@ public:
         return "static";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 private:
 

--- a/rcsc/formation/formation_parser_v1.cpp
+++ b/rcsc/formation/formation_parser_v1.cpp
@@ -39,7 +39,7 @@ namespace rcsc {
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserV1::parse( std::istream & is )
+FormationParserV1::parseImpl( std::istream & is )
 {
     const std::string method = parseHeader( is );
 

--- a/rcsc/formation/formation_parser_v1.h
+++ b/rcsc/formation/formation_parser_v1.h
@@ -66,12 +66,14 @@ public:
         return "v1";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 private:
     std::string parseHeader( std::istream & is );

--- a/rcsc/formation/formation_parser_v2.cpp
+++ b/rcsc/formation/formation_parser_v2.cpp
@@ -41,7 +41,7 @@ namespace rcsc {
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserV2::parse( std::istream & is )
+FormationParserV2::parseImpl( std::istream & is )
 {
     const std::string method = parseHeader( is );
 

--- a/rcsc/formation/formation_parser_v2.h
+++ b/rcsc/formation/formation_parser_v2.h
@@ -67,12 +67,14 @@ public:
         return "v2";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 private:
 

--- a/rcsc/formation/formation_parser_v3.cpp
+++ b/rcsc/formation/formation_parser_v3.cpp
@@ -39,7 +39,7 @@ namespace rcsc {
 
 /*-------------------------------------------------------------------*/
 Formation::Ptr
-FormationParserV3::parse( std::istream & is )
+FormationParserV3::parseImpl( std::istream & is )
 {
     const std::string method = parseHeader( is );
 

--- a/rcsc/formation/formation_parser_v3.h
+++ b/rcsc/formation/formation_parser_v3.h
@@ -67,12 +67,14 @@ public:
         return "v3";
     }
 
+protected:
+
     /*!
       \brief parse the input stream
       \param is reference to the input stream to be parsed
       \return formation instance
      */
-    Formation::Ptr parse( std::istream & is ) override;
+    Formation::Ptr parseImpl( std::istream & is ) override;
 
 private:
 


### PR DESCRIPTION
…ow, users just need to call FormationParser::parse() when creating the formation instance.
Close #44 