### PR TITLE
InterceptSimulatorSelfV17を修正．

### DIFF
--- a/rcsc/player/intercept_simulator_self_v17.cpp
+++ b/rcsc/player/intercept_simulator_self_v17.cpp
@@ -1215,11 +1215,11 @@ InterceptSimulatorSelfV17::getTurnDash( const WorldModel & wm,
     const Vector2D ball_rel = rotate_matrix.transform( ball_pos - wm.self().pos() );
 
     const int max_dash_step = step - n_turn;
-    const Vector2D self_final_pos = inertia_n_step_point( self_pos, self_vel, max_dash_step, ptype.playerDecay() );
 
     double first_dash_power = 0.0;
     for ( int i = 0; i < max_dash_step; ++i )
     {
+        const Vector2D self_final_pos = inertia_n_step_point( self_pos, self_vel, max_dash_step - i, ptype.playerDecay() );
         double required_vel_x = ( ball_rel.x - self_final_pos.x )
             * ( 1.0 - ptype.playerDecay() )
             / ( 1.0 - std::pow( ptype.playerDecay(), max_dash_step - i ) );
@@ -1341,9 +1341,8 @@ InterceptSimulatorSelfV17::simulateOmniDashAny( const WorldModel & wm,
                                       ? 0.0
                                       : CONTROL_BUF + ball_noise );
 
-        const Vector2D self_final_pos = wm.self().inertiaPoint( ball_step );
-
-        const Vector2D ball_rel = rotate_matrix.transform( ball_pos - self_final_pos );
+        //const Vector2D ball_rel = rotate_matrix.transform( ball_pos - self_final_pos );
+        const Vector2D ball_rel = rotate_matrix.transform( ball_pos - wm.self().inertiaPoint( ball_step ) );
         if ( ball_rel.absY() - control_area > max_side_speed * ball_step )
         {
             continue;
@@ -1360,6 +1359,7 @@ InterceptSimulatorSelfV17::simulateOmniDashAny( const WorldModel & wm,
 
         for ( int step = 1; step <= ball_step; ++step )
         {
+            const Vector2D self_final_pos = inertia_n_step_point( self_pos, self_vel, ball_step - step + 1, ptype.playerDecay() );
             const Vector2D required_vel = ( ball_pos - self_final_pos )
                 * ( ( 1.0 - ptype.playerDecay() )
                     / ( 1.0 - std::pow( ptype.playerDecay(), ball_step - step + 1 ) ) );
@@ -1560,9 +1560,9 @@ InterceptSimulatorSelfV17::simulateOmniDashOld( const WorldModel & wm,
                       "%d: ball_pos=(%.2f %.2f) ball_noise=%.3f",
                       reach_step, ball_pos.x, ball_pos.y, ball_noise );
 #endif
-        const Vector2D self_final_pos = inertia_n_step_point( self_pos, self_vel, reach_step, ptype.playerDecay() );
         for ( int step = 1; step <= reach_step; ++step )
         {
+            const Vector2D self_final_pos = inertia_n_step_point( self_pos, self_vel, reach_step - step + 1, ptype.playerDecay() );
             const Vector2D required_vel = ( ball_pos - self_final_pos )
                 * ( ( 1.0 - ptype.playerDecay() )
                     / ( 1.0 - std::pow( ptype.playerDecay(), reach_step - step + 1 ) ) );


### PR DESCRIPTION
慣性移動位置を求める位置をループ内部へ移動．
慣性移動位置をループ外で求めてしまうと予測計算が狂うため，アルゴリズムとしてバグが発生していた．